### PR TITLE
depend on dev dtplyr, which seems to fix #24

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,3 +43,6 @@ Collate:
     'show_dplyr.R'
     'unscope.R'
 Config/testthat/edition: 3
+Remotes:
+  tidyverse/dtplyr,
+  tidyverse/tidyr

--- a/tests/testthat/test-errors.R
+++ b/tests/testthat/test-errors.R
@@ -93,6 +93,7 @@ test_that("query() fails with two identical expressions with no aliases", {
 })
 
 test_that("query() fails on two very long expressions with no aliases", {
+  skip("no longer fails")
   expect_error(
     query("SELECT 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+2 FROM games"),
     "alias"


### PR DESCRIPTION
closes #24

`dtplyr` will be released soon: https://github.com/tidyverse/dtplyr/issues/302

``` r
library(tidyverse)
library(tidyquery)

base_url <- "https://raw.githubusercontent.com/ianmcook/coursera-datasets/master/"
games         <<- as_tibble(read.table(file = paste0(base_url, "games.txt"),         header = TRUE, sep = "\t", quote = "", stringsAsFactors = FALSE))
query("SELECT 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+2 FROM games")
#> # A tibble: 5 × 2
#>   `... + 1` `... + 2`
#>       <dbl>     <dbl>
#> 1        20        21
#> 2        20        21
#> 3        20        21
#> 4        20        21
#> 5        20        21
```

<sup>Created on 2021-11-30 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1.9000)</sup>

<details style="margin-bottom:10px;">

<summary>Session info</summary>

``` r
sessioninfo::session_info()
#> ─ Session info  👩🏽‍🔬  🇨🇱  🤶🏾   ─────────────────────────────────────────────────
#>  hash: woman scientist: medium skin tone, flag: Chile, Mrs. Claus: medium-dark skin tone
#> 
#>  setting  value
#>  version  R version 4.0.3 (2020-10-10)
#>  os       macOS Big Sur 10.16
#>  system   x86_64, darwin17.0
#>  ui       X11
#>  language (EN)
#>  collate  en_US.UTF-8
#>  ctype    en_US.UTF-8
#>  tz       Europe/Paris
#>  date     2021-11-30
#>  pandoc   2.9.2.1 @ /Applications/RStudio.app/Contents/MacOS/pandoc/ (via rmarkdown)
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version     date (UTC) lib source
#>  assertthat    0.2.1       2019-03-21 [1] CRAN (R 4.0.0)
#>  backports     1.4.0       2021-11-23 [1] CRAN (R 4.0.2)
#>  broom         0.7.10      2021-10-31 [1] CRAN (R 4.0.2)
#>  cellranger    1.1.0       2016-07-27 [1] CRAN (R 4.0.0)
#>  cli           3.1.0       2021-10-27 [1] CRAN (R 4.0.2)
#>  colorspace    2.0-2       2021-06-24 [1] CRAN (R 4.0.2)
#>  crayon        1.4.2       2021-10-29 [1] CRAN (R 4.0.2)
#>  DBI           1.1.1       2021-01-15 [1] CRAN (R 4.0.2)
#>  dbplyr        2.1.1       2021-04-06 [1] CRAN (R 4.0.2)
#>  digest        0.6.28      2021-09-23 [1] CRAN (R 4.0.2)
#>  dplyr       * 1.0.7.9000  2021-11-29 [1] local
#>  ellipsis      0.3.2       2021-04-29 [1] CRAN (R 4.0.3)
#>  evaluate      0.14        2019-05-28 [1] CRAN (R 4.0.0)
#>  fansi         0.5.0       2021-05-25 [1] CRAN (R 4.0.3)
#>  fastmap       1.1.0       2021-01-25 [1] CRAN (R 4.0.2)
#>  forcats     * 0.5.1       2021-01-27 [1] CRAN (R 4.0.2)
#>  fs            1.5.0       2020-07-31 [1] CRAN (R 4.0.2)
#>  generics      0.1.1       2021-10-25 [1] CRAN (R 4.0.2)
#>  ggplot2     * 3.3.5       2021-06-25 [1] CRAN (R 4.0.2)
#>  glue          1.5.0       2021-11-07 [1] CRAN (R 4.0.2)
#>  gtable        0.3.0       2019-03-25 [1] CRAN (R 4.0.0)
#>  haven         2.4.3       2021-08-04 [1] CRAN (R 4.0.2)
#>  highr         0.9         2021-04-16 [1] CRAN (R 4.0.2)
#>  hms           1.1.1       2021-09-26 [1] CRAN (R 4.0.2)
#>  htmltools     0.5.2       2021-08-25 [1] CRAN (R 4.0.2)
#>  httr          1.4.2       2020-07-20 [1] CRAN (R 4.0.2)
#>  jsonlite      1.7.2       2020-12-09 [1] CRAN (R 4.0.2)
#>  knitr         1.36        2021-09-29 [1] CRAN (R 4.0.2)
#>  lifecycle     1.0.1       2021-09-24 [1] CRAN (R 4.0.2)
#>  lubridate     1.8.0       2021-10-07 [1] CRAN (R 4.0.2)
#>  magrittr      2.0.1       2020-11-17 [1] CRAN (R 4.0.2)
#>  modelr        0.1.8       2020-05-19 [1] CRAN (R 4.0.1)
#>  munsell       0.5.0       2018-06-12 [1] CRAN (R 4.0.0)
#>  pillar        1.6.4       2021-10-18 [1] CRAN (R 4.0.2)
#>  pkgconfig     2.0.3       2019-09-22 [1] CRAN (R 4.0.0)
#>  purrr       * 0.3.4       2020-04-17 [1] CRAN (R 4.0.0)
#>  queryparser   0.3.1       2021-01-17 [1] CRAN (R 4.0.2)
#>  R.cache       0.15.0      2021-04-30 [1] CRAN (R 4.0.2)
#>  R.methodsS3   1.8.1       2020-08-26 [1] CRAN (R 4.0.2)
#>  R.oo          1.24.0      2020-08-26 [1] CRAN (R 4.0.2)
#>  R.utils       2.11.0      2021-09-26 [1] CRAN (R 4.0.2)
#>  R6            2.5.1       2021-08-19 [1] CRAN (R 4.0.2)
#>  Rcpp          1.0.7       2021-07-07 [1] CRAN (R 4.0.2)
#>  readr       * 2.1.0       2021-11-11 [1] CRAN (R 4.0.2)
#>  readxl        1.3.1       2019-03-13 [1] CRAN (R 4.0.0)
#>  reprex        2.0.1.9000  2021-10-01 [1] Github (tidyverse/reprex@9ca939f)
#>  rlang         0.99.0.9001 2021-11-29 [1] Github (r-lib/rlang@5aefc4a)
#>  rmarkdown     2.11        2021-09-14 [1] CRAN (R 4.0.2)
#>  rstudioapi    0.13        2020-11-12 [1] CRAN (R 4.0.2)
#>  rvest         1.0.2       2021-10-16 [1] CRAN (R 4.0.2)
#>  scales        1.1.1       2020-05-11 [1] CRAN (R 4.0.0)
#>  sessioninfo   1.2.1       2021-11-02 [1] CRAN (R 4.0.2)
#>  stringi       1.7.6       2021-11-29 [1] CRAN (R 4.0.3)
#>  stringr     * 1.4.0       2019-02-10 [1] CRAN (R 4.0.2)
#>  styler        1.6.2       2021-09-23 [1] CRAN (R 4.0.2)
#>  tibble      * 3.1.6       2021-11-07 [1] CRAN (R 4.0.3)
#>  tidyquery   * 0.2.2.9003  2021-11-30 [1] local
#>  tidyr       * 1.1.4.9000  2021-11-30 [1] Github (tidyverse/tidyr@b2c0fc3)
#>  tidyselect    1.1.1       2021-04-30 [1] CRAN (R 4.0.2)
#>  tidyverse   * 1.3.1       2021-04-15 [1] CRAN (R 4.0.2)
#>  tzdb          0.2.0       2021-10-27 [1] CRAN (R 4.0.2)
#>  utf8          1.2.2       2021-07-24 [1] CRAN (R 4.0.2)
#>  vctrs         0.3.8       2021-04-29 [1] CRAN (R 4.0.2)
#>  withr         2.4.2       2021-04-18 [1] CRAN (R 4.0.2)
#>  xfun          0.28        2021-11-04 [1] CRAN (R 4.0.2)
#>  xml2          1.3.2       2020-04-23 [1] CRAN (R 4.0.0)
#>  yaml          2.2.1       2020-02-01 [1] CRAN (R 4.0.0)
#> 
#>  [1] /Users/romainfrancois/.R/library/4.0
#>  [2] /Library/Frameworks/R.framework/Versions/4.0/Resources/library
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>

 