### PR TITLE
Support the arrow package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Suggests:
     DBI (>= 0.7),
     dbplyr (>= 1.2.1),
     dtplyr (>= 1.0.0),
+    arrow (>= 9.0.0),
     nycflights13,
     RSQLite (>= 2.1.0),
     testthat (>= 3.0.0)

--- a/R/compat.R
+++ b/R/compat.R
@@ -28,7 +28,15 @@ deparse <- function(expr, width.cutoff = 500, ...) {
 is_supported_data_object <- function(obj) {
   inherits(
     obj,
-    c("data.frame", "tbl", "dtplyr_step", "disk.frame", "arrow_dplyr_query", "ArrowTabular")
+    c(
+      "data.frame",
+      "tbl",
+      "dtplyr_step",
+      "disk.frame",
+      "arrow_dplyr_query",
+      "ArrowTabular",
+      "Dataset"
+    )
   )
 }
 is_grouped_data_object <- function(obj) {
@@ -40,8 +48,10 @@ data_object_uses_function_translations <- function(obj) {
 column_names <- function(obj) {
   if (inherits(obj, "dtplyr_step")) {
     obj$vars
-  } else {
+  } else if (inherits(obj, "tbl")) {
     colnames(obj)
+  } else {
+    names(obj)
   }
 }
 

--- a/R/compat.R
+++ b/R/compat.R
@@ -26,16 +26,13 @@ deparse <- function(expr, width.cutoff = 500, ...) {
 
 # to support data frame-like objects
 is_supported_data_object <- function(obj) {
-  inherits(obj, c("data.frame", "tbl", "dtplyr_step", "disk.frame"))
+  inherits(
+    obj,
+    c("data.frame", "tbl", "dtplyr_step", "disk.frame", "arrow_dplyr_query", "ArrowTabular")
+  )
 }
 is_grouped_data_object <- function(obj) {
-  if (inherits(obj, "tbl_sql") && ("dbplyr" %in% .packages(all.available = TRUE))) {
-    length(dbplyr::op_grps(obj)) > 0
-  } else if (inherits(obj, "dtplyr_step")) {
-    length(obj$groups) > 0
-  } else {
-    inherits(obj, c("grouped_df", "grouped_disk.frame"))
-  }
+  inherits(obj, "grouped_disk.frame") || length(dplyr::group_vars(obj))
 }
 data_object_uses_function_translations <- function(obj) {
   inherits(obj, c("tbl_sql", "dtplyr_step", "disk.frame"))

--- a/tests/testthat/test-arrow.R
+++ b/tests/testthat/test-arrow.R
@@ -1,0 +1,72 @@
+test_that("Simple SELECT example query #1 returns expected result on ArrowTabular", {
+  skip_if_not_installed("arrow")
+  iris_arrow <- arrow::arrow_table(iris)
+  expect_equal(
+    query(
+      "SELECT Species, COUNT(*) AS n FROM iris_arrow GROUP BY Species"
+    ) %>% collect(),
+    iris_arrow %>%
+      group_by(Species) %>%
+      summarise(n = n()) %>%
+      ungroup() %>%
+      collect()
+  )
+})
+
+test_that("Full example #1 returns expected result on ArrowTabular", {
+  skip_if_not_installed("arrow")
+  skip_if_not_installed("nycflights13")
+  flights_arrow <- arrow::arrow_table(nycflights13::flights)
+  expect_equal(
+    suppressWarnings(query(
+      "SELECT origin, dest,
+          COUNT(flight) AS num_flts,
+          round(AVG(distance)) AS dist,
+          round(AVG(arr_delay)) AS avg_delay
+          FROM flights_arrow
+        WHERE distance BETWEEN 200 AND 300
+          AND air_time IS NOT NULL
+        GROUP BY origin, dest
+        HAVING num_flts > 3000
+        ORDER BY num_flts DESC, avg_delay DESC
+        LIMIT 100;"
+    ) %>% collect()),
+    suppressWarnings(flights_arrow %>%
+      filter(between(distance, 200, 300) & !is.na(air_time)) %>%
+      group_by(origin, dest) %>%
+      filter(sum(!is.na(flight)) > 3000) %>%
+      summarise(
+        num_flts = sum(!is.na(flight)),
+        dist = round(mean(distance, na.rm = TRUE)),
+        avg_delay = round(mean(arr_delay, na.rm = TRUE))
+      ) %>%
+      ungroup() %>%
+      arrange(desc(num_flts), desc(avg_delay)) %>%
+      head(100L) %>%
+      collect())
+  )
+})
+
+test_that("query() fails when input ArrowTabular is grouped", {
+  skip_if_not_installed("arrow")
+  skip_if_not_installed("nycflights13")
+  expect_error(
+    nycflights13::flights %>%
+      group_by(month) %>%
+      arrow::arrow_table() %>%
+      query("SELECT COUNT(*)"),
+    "grouped"
+  )
+})
+
+test_that("query() fails when input arrow_dplyr_query is grouped", {
+  skip_if_not_installed("arrow")
+  skip_if_not_installed("nycflights13")
+  expect_error(
+    nycflights13::flights %>%
+      arrow::arrow_table() %>%
+      group_by(month) %>%
+      query("SELECT COUNT(*)"),
+    "grouped"
+  )
+})

--- a/tests/testthat/test-arrow.R
+++ b/tests/testthat/test-arrow.R
@@ -47,6 +47,26 @@ test_that("Full example #1 returns expected result on ArrowTabular", {
   )
 })
 
+test_that("Simple SELECT example query #1 returns expected result on arrow Dataset", {
+  skip_if_not_installed("arrow")
+  skip_if_not(arrow::arrow_info()$capabilities["dataset"], message = "Arrow Datasets not available")
+
+  tmp <- tempfile()
+  on.exit(unlink(tmp))
+  arrow::write_parquet(iris, tmp)
+  iris_arrow <- arrow::open_dataset(tmp)
+  expect_equal(
+    query(
+      "SELECT Species, COUNT(*) AS n FROM iris_arrow GROUP BY Species"
+    ) %>% collect(),
+    iris_arrow %>%
+      group_by(Species) %>%
+      summarise(n = n()) %>%
+      ungroup() %>%
+      collect()
+  )
+})
+
 test_that("query() fails when input ArrowTabular is grouped", {
   skip_if_not_installed("arrow")
   skip_if_not_installed("nycflights13")


### PR DESCRIPTION
Thanks for creating this great package.

Since the package I recently created can be used with tidyquery[^1], I thought it would be even more wonderful to be able to support arrow here.
Please let me know if there is anything you think needs to be done to support arrow so I may work on it.

Close #16

[^1]: <https://eitsupi.github.io/prqlr/articles/prqlr.html#work-with-r-data-frame>